### PR TITLE
Remove validation requiring idc arn for Application create

### DIFF
--- a/aws-qbusiness-application/src/main/java/software/amazon/qbusiness/application/Translator.java
+++ b/aws-qbusiness-application/src/main/java/software/amazon/qbusiness/application/Translator.java
@@ -18,7 +18,6 @@ import software.amazon.awssdk.services.qbusiness.model.Tag;
 import software.amazon.awssdk.services.qbusiness.model.TagResourceRequest;
 import software.amazon.awssdk.services.qbusiness.model.UntagResourceRequest;
 import software.amazon.awssdk.services.qbusiness.model.UpdateApplicationRequest;
-import software.amazon.cloudformation.exceptions.CfnInvalidRequestException;
 import software.amazon.cloudformation.proxy.ResourceHandlerRequest;
 
 /**
@@ -37,10 +36,6 @@ public class Translator {
    * @return awsRequest the aws service request to create a resource
    */
   static CreateApplicationRequest translateToCreateRequest(final String idempotentToken, final ResourceModel model) {
-    // https://w.amazon.com/bin/view/AWS21/Design/Uluru/Onboarding_Guide/ModelingGuidelines#HRequiredWriteOnlyProperties
-    if (model.getIdentityCenterInstanceArn() == null) {
-      throw new CfnInvalidRequestException("IdentityCenterInstanceArn is required.");
-    }
     return CreateApplicationRequest.builder()
         .clientToken(idempotentToken)
         .displayName(model.getDisplayName())


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
This change removes the validation logic requiring IDC arn. At the moment, this is not a required for all users. So we should not do this validation here.

Let's leave that validation to be done by the service.
----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
